### PR TITLE
bandwidth charges for copying objects

### DIFF
--- a/api-reference/api-reference-objects.md
+++ b/api-reference/api-reference-objects.md
@@ -394,6 +394,8 @@ A `PUT` given a path to a new object creates a new copy of another object that i
 **Note**: Personally Identifiable Information (PII): When creating buckets and/or adding objects, please ensure to not use any information that can identify any user (natural person) by name, location, or any other means.
 {:tip}
 
+**Note**: Copying objects (even across locations) does not incur the public outbound bandwidth charges. All data remains inside the COS internal network.
+{:tip}
 
 **Note**: Copying an item from a *Key Protect*-enabled bucket to a destination bucket in another region is restricted and will result in a `500 - Internal Error`.
 {:tip}


### PR DESCRIPTION
Add the note about bandwidth charges for copying objects

https://ibm-cloud.slack.com/archives/C0VJSU370/p1567172906098200?thread_ts=1567065240047900&cid=C0VJSU370
＞REST.COPY.OBJECT is implemented entirely internal to COS.  
＞The data never transfers northbound of the Accesser appliances so the question of private vs public does not apply.  
＞All data remains inside the COS internal network.