### PR TITLE
fix: get protection code example syntax error

### DIFF
--- a/libraries/node.md
+++ b/libraries/node.md
@@ -754,7 +754,7 @@ function getProtectionConfigurationOnBucket(bucketName) {
     .then((data) => {
         console.log(`Configuration on bucket ${bucketName}:`);
         console.log(data);
-    }
+    })
     .catch((e) => {
         console.log(`ERROR: ${e.code} - ${e.message}\n`);
     });


### PR DESCRIPTION
Fixed a syntax error in getProtectionConfigurationOnBucket function example in `IBM Cloud Docs`/`Cloud Object Storage`/`Using Node.js`.